### PR TITLE
fix: EmbeddingFunction trait - Send + Sync bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chromadb"
-version = "0.5.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/v2/embeddings/mod.rs
+++ b/src/v2/embeddings/mod.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 pub mod openai;
 
 #[async_trait]
-pub trait EmbeddingFunction {
+pub trait EmbeddingFunction: Send + Sync {
     async fn embed(&self, docs: &[&str]) -> Result<Vec<Embedding>>;
 }
 
@@ -19,4 +19,3 @@ impl EmbeddingFunction for MockEmbeddingProvider {
         Ok(docs.iter().map(|_| vec![0.0_f32; 768]).collect())
     }
 }
-


### PR DESCRIPTION
Added Send + Sync bounds to EmbeddingFunction trait to ensure thread safety.