### PR TITLE
feat: add configuration json field to chroma collection

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -234,6 +234,7 @@ mod tests {
 
         let collection = client.get_collection(GET_TEST_COLLECTION).await.unwrap();
         assert_eq!(collection.name(), GET_TEST_COLLECTION);
+        assert!(collection.configuration_json.is_some());
     }
 
     #[tokio::test]

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -5,7 +5,7 @@ use std::{collections::HashSet, sync::Arc, vec};
 
 use super::{
     api::APIClientAsync,
-    commons::{Documents, Embedding, Embeddings, Metadata, Metadatas, Result},
+    commons::{Documents, Embedding, Embeddings, Metadata, Metadatas, Result, ConfigurationJson},
     embeddings::EmbeddingFunction,
 };
 
@@ -17,6 +17,7 @@ pub struct ChromaCollection {
     pub(super) id: String,
     pub(super) metadata: Option<Metadata>,
     pub(super) name: String,
+    pub(super) configuration_json: Option<ConfigurationJson>
 }
 
 impl ChromaCollection {

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -1,6 +1,7 @@
 use serde_json::{Map, Value};
 
 pub(super) type Result<T> = anyhow::Result<T>;
+pub(super) type ConfigurationJson = Map<String, Value>;
 pub(super) type Metadata = Map<String, Value>;
 pub(super) type Metadatas = Vec<Metadata>;
 pub(super) type Embedding = Vec<f32>;


### PR DESCRIPTION
add a `configuration_json` field to the `ChromaCollection` struct to enable fetching and accessing the configuration json