### PR TITLE
fix: metadata deserialization/type issue in GetResult struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chromadb"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -362,7 +362,7 @@ impl ChromaCollection {
 #[derive(Deserialize, Debug)]
 pub struct GetResult {
     pub ids: Vec<String>,
-    pub metadatas: Option<Vec<Option<Vec<Option<Metadata>>>>>,
+    pub metadatas: Option<Vec<Option<Metadata>>>,
     pub documents: Option<Vec<Option<String>>>,
     pub embeddings: Option<Vec<Option<Embedding>>>,
 }

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -752,6 +752,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_all_metadatas_from_collection() {
+        let client = ChromaClient::new(Default::default());
+
+        let collection = client
+            .await
+            .unwrap()
+            .get_or_create_collection(TEST_COLLECTION, None)
+            .await
+            .unwrap();
+
+        let test_metadatas = vec![
+            json!({"key1": "value1"}).as_object().unwrap().clone(),
+            json!({"key2": "value2"}).as_object().unwrap().clone(),
+        ];
+
+        let collection_entries = CollectionEntries {
+            ids: vec!["test1", "test2"],
+            metadatas: Some(test_metadatas),
+            documents: Some(vec!["Document content 1", "Document content 2"]),
+            embeddings: None,
+        };
+
+        let response = collection.add(collection_entries, Some(Box::new(MockEmbeddingProvider)));
+        assert!(response.await.is_ok());
+
+        let get_query = GetOptions {
+            ids: vec![],
+            where_metadata: None,
+            limit: None,
+            offset: None,
+            where_document: None,
+            include: Some(vec!["metadatas".into()]),
+        };
+
+        let get_result = collection.get(get_query).await.unwrap();
+
+        assert!(
+            get_result.metadatas.is_some(),
+            "Expected metadata to be present in the response"
+        );
+
+        assert_eq!(
+            get_result.metadatas.unwrap().len(),
+            2,
+            "Expected two metadata entries in the response"
+        );
+    }
+
+    #[tokio::test]
     async fn test_update_collection() {
         let client = ChromaClient::new(Default::default());
 


### PR DESCRIPTION
This PR fixes **Incorrect Metadata Deserialization in Rust Client (GetResult Struct) #24**.  

### **Issue:**  
The `GetResult` struct expected:  
```rust
pub metadatas: Option<Vec<Option<Vec<Option<Metadata>>>>>,
```
But the API returns:  
```rust
pub metadatas: Option<Vec<Option<Metadata>>>,
```
This mismatch caused a deserialization error:  
```
error decoding response body: invalid type: map, expected a sequence at line 1 column 3571
```

### **Fix:**  
- Changed `metadatas` type in `GetResult` to correctly match the API response.  
- Added test case `test_get_all_metadatas_from_collection` to verify fetching metadata from a collection.  

### **Example from Chroma Docs:**  
```js
metadatas: [{ "key": "value" }, { "key": "value" }]
```

### **Result:**  
With this fix, the Rust client now correctly deserializes metadata, allowing users to get collection data along with metadata without encountering errors.  

### **Example Usage:**  
Here’s how to fetch collection data with metadata:

```rust
let get_query = GetOptions {
    ids: vec![],
    where_metadata: None,
    limit: None,
    offset: None,
    where_document: None,
    include: Some(vec!["metadatas".into()]),
};

let get_result = collection.get(get_query).await.unwrap();
```

This example shows how to get data from a collection, including metadata, without any deserialization issues.
